### PR TITLE
Remove line endings pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,9 +36,6 @@ repos:
   hooks:
   - id: check-case-conflict
   - id: end-of-file-fixer
-  - id: mixed-line-ending
-    args:
-    - --fix=lf
   - id: trailing-whitespace
   - id: pretty-format-json
     args:


### PR DESCRIPTION
Does not play nice with standard windows git settings (check out crlf commit lf). 