### PR TITLE
License replacement in `pyproject.toml`

### DIFF
--- a/setup_template.py
+++ b/setup_template.py
@@ -92,6 +92,9 @@ def main() -> None:
         content = content.replace("Reinder Vos de Wael", username)
 
         content = licenses.replace_license_badge(content, repo_license)
+        content = content.replace(
+            "LGPL-2.1", repo_license["name"] if repo_license else ""
+        )
 
         if content != content_before:
             print(f"Updating {file.relative_to(DIR_REPO)}")


### PR DESCRIPTION
After running through the setup - if a different license is chosen, it is updated everywhere but the `pyproject.toml` file. This PR just replaces the license in the content with the `repo_license["name"]` (though maybe this should be the `repo_license["spdx_id"]` if it should be kept in the same form?