### PR TITLE
Add codecov.yaml configuration file

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 0%
+    patch:
+      default:
+        target: 0%


### PR DESCRIPTION
This pull request adds a codecov.yaml configuration file to the project. The file includes coverage status settings for the project and patch levels. The project level target coverage is set to 80% with a threshold of 0%, while the patch level target coverage is set to 0%. 

We can tinker with the exact numbers, but overall a 80% target seems like a good minimum to me. Targets on patches seem overkill to me and can be annyoing during refactor/chore PRs.