### PR TITLE
Remove dummy-variable-rgx ruff setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ ignore = [
 ]
 fixable = ["ALL"]
 unfixable = []
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"


### PR DESCRIPTION
This is the default
https://docs.astral.sh/ruff/settings/#lint_dummy-variable-rgx