### PR TITLE
Deploy pages directly from gh actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,11 +1,19 @@
 name: Build and publish docs
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+  # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+  group: "pages"
+  cancel-in-progress: false
 
 on:
   workflow_run:
-    workflows: [Python Tests]
+    workflows: [ Python Tests ]
     types:
     - completed
     branches:
@@ -15,6 +23,9 @@ jobs:
   build-and-publish-docs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - uses: actions/checkout@v4
     - name: Install uv
@@ -31,7 +42,12 @@ jobs:
       run: |
         APP_MODULE_NAME=$(ls src -U | head -1)  # Get the first module name in the src directory
         uv run pdoc src/"$APP_MODULE_NAME" -o docs_build -t docs/pdoc-theme --docformat google
-        touch docs_build/.nojekyll
-    - uses: JamesIves/github-pages-deploy-action@v4
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v4
       with:
-        folder: docs_build
+        path: './docs_build'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,12 +8,12 @@ permissions:
 concurrency:
   # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
   # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 on:
   workflow_run:
-    workflows: [ Python Tests ]
+    workflows: [Python Tests]
     types:
     - completed
     branches:
@@ -49,7 +49,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v4
       with:
-        path: './docs_build'
+        path: ./docs_build
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,6 +18,8 @@ on:
     - completed
     branches:
     - main
+  workflow_dispatch:
+
 
 jobs:
   build-and-publish-docs:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Welcome to the CMI-DAIR Template Python Repository! This template is designed to
 - [ ] Revise SECURITY.md to reflect supported versions or remove it if not applicable.
 - [ ] Remove the placeholder src and test files, these are there merely to show how the CI works.
 - [ ] If it hasn't already been done for your organization/acccount, grant third-party app permissions for CodeCov.
-- [ ] To set up an API documentation website, after the first successful build, go to the `Settings` tab of your repository, scroll down to the `GitHub Pages` section, and select `gh-pages` as the source. This will generate a link to your API docs.
+- [ ] To set up an API documentation website, go to the `Settings` tab of your repository, scroll down to the `GitHub Pages` section, and select `GitHub Actions` as the source. This will generate a link to your API docs.
 - [ ] Update stability badge in `README.md` to reflect the current state of the project. A list of stability badges to copy can be found [here](https://github.com/orangemug/stability-badges). The [node documentation](https://nodejs.org/docs/latest-v20.x/api/documentation.html#documentation_stability_index) can be used as a reference for the stability levels.
 
 # Project name


### PR DESCRIPTION
- No pages branch anymore
- No repo write permission for docs workflow
- No .nojekyll
- No 3rd party action for deployments
- Success

Manually delete pages branch after merge