### PR TITLE
Change package-ecosystem from pip to uv

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,7 +3,7 @@
 
 version: 2
 updates:
-- package-ecosystem: pip
+- package-ecosystem: uv
   directory: /
   schedule:
     interval: monthly


### PR DESCRIPTION
From https://github.com/childmindresearch/rbc/pull/338#issuecomment-4508832880, changing the dependabot package-ecosystem from `pip` to `uv` which will update the `uv.lock` in addition to the `pyproject.toml`